### PR TITLE
Indentation fix

### DIFF
--- a/duplicate_lines.py
+++ b/duplicate_lines.py
@@ -8,7 +8,7 @@ class DuplicateLinesCommand(sublime_plugin.TextCommand):
                 line_contents = self.view.substr(line) + '\n'
                 self.view.insert(edit, line.begin(), line_contents)
             else:
-            	line = self.view.line(region)
-            	self.view.run_command("expand_selection", {"to": line.begin()})
-            	region_contents = self.view.substr(self.view.line(region)) + '\n'
+                line = self.view.line(region)
+                self.view.run_command("expand_selection", {"to": line.begin()})
+                region_contents = self.view.substr(self.view.line(region)) + '\n'
                 self.view.insert(edit, line.begin(), region_contents)


### PR DESCRIPTION
inconsistent use of tabs and spaces-for-tabs caused this error in Sublime Text 3:
`TabError: inconsistent use of tabs and spaces in indentation`
