### PR TITLE
Add ability to perform 'duplicate up'.

### DIFF
--- a/duplicate_lines.py
+++ b/duplicate_lines.py
@@ -1,14 +1,8 @@
 import sublime, sublime_plugin
 
 class DuplicateLinesCommand(sublime_plugin.TextCommand):
-    def run(self, edit):
+    def run(self, edit, **args):
         for region in self.view.sel():
-            if region.empty():
-                line = self.view.line(region)
-                line_contents = self.view.substr(line) + '\n'
-                self.view.insert(edit, line.begin(), line_contents)
-            else:
-                line = self.view.line(region)
-                self.view.run_command("expand_selection", {"to": line.begin()})
-                region_contents = self.view.substr(self.view.line(region)) + '\n'
-                self.view.insert(edit, line.begin(), region_contents)
+            line = self.view.full_line(region)
+            line_contents = self.view.substr(line)
+            self.view.insert(edit, line.end() if args.get('up', False) else line.begin(), line_contents)


### PR DESCRIPTION
Hi,

I was going to submit my own plugin to Package Control, but decided to try sending you a pull request first.

Here's my plugin:
https://github.com/harawata/sublime-duplicate-line-eclipse
As shown in the README, your plugin has **Copy Lines** behavior already and I would like to add **Duplicate Lines** behavior.
Please see the .sublime-keymap file for how to assign key bindings.
This change should be backward compatible.

What do you think?

Best regards,
Iwao
