### PR TITLE
Added "Duplicate Line Up" Command to Documentation

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,3 +1,4 @@
 [
-  { "keys": ["ctrl+alt+d"], "command": "duplicate_lines" }
+  { "keys": ["ctrl+alt+d"], "command": "duplicate_lines" },
+  { "keys": ["ctrl+alt+u"], "command": "duplicate_lines", "args": { "up": true } }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,3 +1,4 @@
 [
-  { "keys": ["super+shift+d"], "command": "duplicate_lines" }
+  { "keys": ["super+shift+d"], "command": "duplicate_lines" },
+  { "keys": ["super+shift+u"], "command": "duplicate_lines", "args": { "up": true } }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,3 +1,4 @@
 [
-  { "keys": ["ctrl+alt+d"], "command": "duplicate_lines" }
+  { "keys": ["ctrl+alt+d"], "command": "duplicate_lines" },
+  { "keys": ["ctrl+alt+u"], "command": "duplicate_lines", "args": { "up": true } }
 ]

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Without Package Manager
 4. Edit your Key Bindings - User file (and bind whatever command to it that you want)
 
 ```{ "keys": ["super+shift+d"], "command": "duplicate_lines" }```
+```{ "keys": ["super+shift+u"], "command": "duplicate_lines", "args": { "up": true } }```
 
 
 Enjoy.


### PR DESCRIPTION
I noticed that the documentation didn't mention the `up` argument that the Macro can receive, so I thought I'd add it for others who might be looking for it.