### PR TITLE
Fix caret position when duplicating a single line upwards while at the end of the line

### DIFF
--- a/duplicate_lines.py
+++ b/duplicate_lines.py
@@ -2,6 +2,7 @@ import sublime, sublime_plugin
 
 class DuplicateLinesCommand(sublime_plugin.TextCommand):
     def run(self, edit, up = False):
+        last_caret_region = [(selection.begin(), selection.end()) for selection in self.view.sel()]
         for region in self.view.sel():
             line = self.view.line(region)
             line_contents = self.view.substr(line)
@@ -10,3 +11,8 @@ class DuplicateLinesCommand(sublime_plugin.TextCommand):
               self.view.insert(edit, line.end(), "\n" + line_contents)
             else:
               self.view.insert(edit, line.begin(), line_contents + "\n")
+
+        if up:
+            self.view.sel().clear()
+            for selection in last_caret_region:
+                self.view.sel().add(sublime.Region(selection[0], selection[1]))


### PR DESCRIPTION
When the caret is at the end of the line and nothing is selected if I do a duplicate up, then the caret still ends up at the end of the bottom line instead of the top one. It is working fine when I am anywhere inside the line only broken in this specific case.
The fix is just storing the original selection and restoring it after the duplication in case of duplication in the up direction.
I am not sure if there is an easier solution for this. :D 